### PR TITLE
WIP: TODO: FIX QTBUG-96938

### DIFF
--- a/lib/seasidecontactbuilder.cpp
+++ b/lib/seasidecontactbuilder.cpp
@@ -485,6 +485,8 @@ void SeasideContactBuilder::preprocessContact(QContact &contact)
             setNickname(contact, label);
         }
     }
+
+    // TODO: apply uniqueness constraint for REV (QContactTimestamp) details.
 }
 
 /*


### PR DESCRIPTION
As reported by community member Jozef Mlich:

Importing a vCard which contains multiple REV fields currently
results in an error due to uniqueness / cardinality constraint
failure for the duplicated QContactTimestamp detail.

Perhaps this should be fixed in the qtcontacts-sqlite backend
by merging the timestamp details, but my opinion is that it is
probably best fixed here by preprocessing the import contact
to ensure that such duplicate QContactTimestamp details are merged
prior to the save/store step.