### PR TITLE
[contacts] Add action plugin API and allow action invocation via SeasidePerson::triggerAction(). JB#55390

### DIFF
--- a/lib/defaultseasideactionplugin.cpp
+++ b/lib/defaultseasideactionplugin.cpp
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2021 Jolla Ltd.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#include "defaultseasideactionplugin.h"
+#include "seasidecache.h"
+
+#include <QContactAddress>
+#include <QContactPhoneNumber>
+#include <QContactEmailAddress>
+#include <QContactAnniversary>
+#include <QContactBirthday>
+#include <QContactUrl>
+#include <QContactAction>
+
+#include <QFile>
+#include <QDesktopServices>
+#include <QDate>
+#include <QDBusMessage>
+#include <QDBusConnection>
+#include <QDebug>
+
+namespace {
+
+bool sendDBusMessage(const QDBusMessage &message, const QDBusConnection &conn)
+{
+    const QDBusMessage result = conn.call(message, QDBus::NoBlock);
+    if (result.type() == QDBusMessage::ErrorMessage) {
+        qWarning() << "D-Bus call to" << result.service() << result.path() << result.interface()
+                   << result.member() << "failed:" << result.errorName() << result.errorMessage();
+        return false;
+    }
+    return true;
+}
+
+bool callPhoneNumber(const QString &number, const QString &modemPath)
+{
+    QString methodName;
+    QVariantList args;
+    if (modemPath.isEmpty()) {
+        methodName = QStringLiteral("dial");
+        args << number;
+    } else {
+        methodName = QStringLiteral("dialViaModem");
+        args << modemPath << number;
+    }
+
+    QDBusMessage message = QDBusMessage::createMethodCall(
+                QStringLiteral("com.jolla.voicecall.ui"),
+                QStringLiteral("/"),
+                QStringLiteral("com.jolla.voicecall.ui"),
+                methodName);
+    message.setArguments(args);
+    return sendDBusMessage(message, QDBusConnection::sessionBus());
+}
+
+QDBusMessage messagesAppDBusMessage(const QString &methodName)
+{
+    return QDBusMessage::createMethodCall(
+                    QStringLiteral("org.sailfishos.Messages"),
+                    QStringLiteral("/"),
+                    QStringLiteral("org.sailfishos.Messages"),
+                    methodName);
+}
+
+bool viewCalendarDate(const QDate &date)
+{
+    if (!QFile::exists(QLatin1String("/usr/share/applications/jolla-calendar.desktop"))) {
+        return false;
+    }
+
+    // Rather than showing the contact's actual birth or anniversary date in the calendar,
+    // show the next occurrence of the anniversary of the recorded date
+    const QDate now = QDate::currentDate();
+    QDate nextDate(now.year(), date.month(), date.day());
+    if (now > nextDate) {
+        nextDate = nextDate.addYears(1);
+    }
+    const QString formattedDate = nextDate.toString(Qt::ISODate);
+
+    QDBusMessage message = QDBusMessage::createMethodCall(
+                        QStringLiteral("com.jolla.calendar.ui"),
+                        QStringLiteral("/com/jolla/calendar/ui"),
+                        QStringLiteral("com.jolla.calendar.ui"),
+                        QStringLiteral("viewDate"));
+    message.setArguments(QVariantList() << formattedDate);
+    return sendDBusMessage(message, QDBusConnection::sessionBus());
+}
+
+bool viewAddress(const QContactAddress &address)
+{
+    if (!QFile::exists(QLatin1String("/usr/share/applications/sailfish-maps.desktop"))) {
+        return false;
+    }
+
+    QDBusMessage message = QDBusMessage::createMethodCall(
+                        QStringLiteral("org.sailfishos.maps"),
+                        QStringLiteral("/"),
+                        QStringLiteral("org.sailfishos.maps"),
+                        QStringLiteral("openAddress"));
+    message.setArguments(QVariantList()
+                         << address.street()
+                         << address.locality()
+                         << address.region()
+                         << address.postcode()
+                         << address.country());
+    return sendDBusMessage(message, QDBusConnection::sessionBus());
+}
+
+}
+
+QList<SeasideActionPlugin::ActionInfo> DefaultSeasideActionPlugin::supportedActions(
+        const QContact &contact, const QContactDetail::DetailType &detailType)
+{
+    Q_UNUSED(contact)
+
+    QList<ActionInfo> infoList;
+
+    switch (detailType) {
+    case QContactDetail::TypeAddress:
+        infoList << ActionInfo{ QContactAction::ActionOpenInViewer(), QStringLiteral("image://theme/icon-m-location") };
+        break;
+    case QContactDetail::TypeAnniversary:
+        infoList << ActionInfo{ QContactAction::ActionOpenInViewer(), QStringLiteral("image://theme/icon-m-date") };
+        break;
+    case QContactDetail::TypeBirthday:
+        infoList << ActionInfo{ QContactAction::ActionOpenInViewer(), QStringLiteral("image://theme/icon-m-date") };
+        break;
+    case QContactDetail::TypeEmailAddress:
+        infoList << ActionInfo{ QContactAction::ActionOpenInViewer(), QStringLiteral("image://theme/icon-m-mail") };
+        break;
+    case QContactDetail::TypeOnlineAccount:
+        infoList << ActionInfo{ QContactAction::ActionChat(), QStringLiteral("image://theme/icon-m-message") };
+        break;
+    case QContactDetail::TypePhoneNumber:
+        infoList << ActionInfo{ QContactAction::ActionCall(), QStringLiteral("image://theme/icon-m-call") };
+        infoList << ActionInfo{ QContactAction::ActionSms(), QStringLiteral("image://theme/icon-m-message") };
+        break;
+    case QContactDetail::TypeNote:
+        infoList << ActionInfo{ QContactAction::ActionOpenInViewer(), QStringLiteral("image://theme/icon-m-note") };
+        break;
+    case QContactDetail::TypeUrl:
+        infoList << ActionInfo{ QContactAction::ActionOpenInViewer(), QStringLiteral("image://theme/icon-m-website") };
+        break;
+    default:
+        qWarning() << "supportedActions(): Unhandled detail type" << detailType;
+        break;
+    }
+
+    return infoList;
+}
+
+bool DefaultSeasideActionPlugin::triggerAction(const QString &actionType,
+        const QVariantMap &parameters, const QContact &contact, const QContactDetail &detail)
+{
+    Q_UNUSED(contact)
+
+    switch (detail.type()) {
+    case QContactDetail::TypeAddress:
+    {
+        return viewAddress(static_cast<QContactAddress>(detail));
+    }
+    case QContactDetail::TypeAnniversary:
+    {
+        return viewCalendarDate(detail.value(QContactAnniversary::FieldOriginalDate).toDate());
+    }
+    case QContactDetail::TypeBirthday:
+    {
+        return viewCalendarDate(detail.value(QContactBirthday::FieldBirthday).toDate());
+    }
+    case QContactDetail::TypeEmailAddress:
+    {
+        const QString email = detail.value(QContactEmailAddress::FieldEmailAddress).toString();
+        const QUrl url(QStringLiteral("mailto:") + email);
+        return QDesktopServices::openUrl(url);
+    }
+    case QContactDetail::TypeOnlineAccount:
+    {
+        const QString localUid = detail.value(QContactOnlineAccount__FieldAccountPath).toString();
+        const QString remoteUid = detail.value(QContactOnlineAccount::FieldAccountUri).toString();
+        QDBusMessage message = messagesAppDBusMessage(QStringLiteral("startConversation"));
+        message.setArguments(QVariantList() << localUid << remoteUid);
+        return sendDBusMessage(message, QDBusConnection::sessionBus());
+    }
+    case QContactDetail::TypePhoneNumber:
+    {
+        const QString number = SeasideCache::normalizePhoneNumber(detail.value(QContactPhoneNumber::FieldNumber).toString());
+        if (actionType == QContactAction::ActionCall()) {
+            return callPhoneNumber(number, parameters.value(QStringLiteral("modemPath")).toString());
+        } else if (actionType == QContactAction::ActionSms()) {
+            QDBusMessage message = messagesAppDBusMessage(QStringLiteral("startSMS"));
+            message.setArguments(QVariantList() << number);
+            return sendDBusMessage(message, QDBusConnection::sessionBus());
+        }
+        break;
+    }
+    case QContactDetail::TypeUrl:
+    {
+        return QDesktopServices::openUrl(detail.value(QContactUrl::FieldUrl).toString());
+    }
+    default:
+        break;
+    }
+
+    qWarning() << "Unsupported action" << actionType << "detail type" << detail.type();
+    return false;
+}

--- a/lib/defaultseasideactionplugin.h
+++ b/lib/defaultseasideactionplugin.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2021 Jolla Ltd.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef DEFAULTSEASIDEACTIONPLUGIN_H
+#define DEFAULTSEASIDEACTIONPLUGIN_H
+
+#include "seasideactionplugin.h"
+
+QTCONTACTS_USE_NAMESPACE
+
+class DefaultSeasideActionPlugin : public SeasideActionPlugin
+{
+    Q_OBJECT
+public:
+    QList<ActionInfo> supportedActions(const QContact &contact,
+                                       const QContactDetail::DetailType &detailType) override;
+
+    bool triggerAction(const QString &actionType,
+                       const QVariantMap &parameters,
+                       const QContact &contact,
+                       const QContactDetail &detail) override;
+};
+
+#endif

--- a/lib/lib.pri
+++ b/lib/lib.pri
@@ -25,6 +25,7 @@ HEADERS += \
 
 SOURCES += \
     $$PWD/cacheconfiguration.cpp \
+    $$PWD/defaultseasideactionplugin.cpp \
     $$PWD/seasidecache.cpp \
     $$PWD/seasideexport.cpp \
     $$PWD/seasideimport.cpp \
@@ -39,7 +40,9 @@ PUBLIC_HEADERS = \
     $$PWD/seasideimport.h \
     $$PWD/seasidecontactbuilder.h \
     $$PWD/synchronizelists.h \
-    $$PWD/seasidepropertyhandler.h
+    $$PWD/seasidepropertyhandler.h \
+    $$PWD/seasideactionplugin.h \
+    $$PWD/defaultseasideactionplugin.h
 
 HEADERS += $$PUBLIC_HEADERS
 

--- a/lib/seasideactionplugin.h
+++ b/lib/seasideactionplugin.h
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2021 Jolla Ltd.
+ *
+ * You may use this file under the terms of the BSD license as follows:
+ *
+ * "Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are
+ * met:
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in
+ *     the documentation and/or other materials provided with the
+ *     distribution.
+ *   * Neither the name of Nemo Mobile nor the names of its contributors
+ *     may be used to endorse or promote products derived from this
+ *     software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."
+ */
+
+#ifndef SEASIDEACTIONPLUGIN_H
+#define SEASIDEACTIONPLUGIN_H
+
+#include "contactcacheexport.h"
+
+#include <QList>
+
+#include <QContact>
+#include <QContactDetail>
+#include <QVariantMap>
+
+QTCONTACTS_USE_NAMESPACE
+
+class CONTACTCACHE_EXPORT SeasideActionPlugin : public QObject
+{
+    Q_OBJECT
+public:
+    class ActionInfo
+    {
+    public:
+        QString actionType;
+        QString icon;
+    };
+
+    virtual QList<ActionInfo> supportedActions(const QContact &contact,
+                                               const QContactDetail::DetailType &detailType) = 0;
+
+    virtual bool triggerAction(const QString &actionType,
+                               const QVariantMap &parameters,
+                               const QContact &contact,
+                               const QContactDetail &detail) = 0;
+};
+
+#endif

--- a/lib/seasidecache.cpp
+++ b/lib/seasidecache.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "seasidecache.h"
+#include "defaultseasideactionplugin.h"
 
 #include "synchronizelists.h"
 
@@ -1529,6 +1530,12 @@ QContactCollectionId SeasideCache::aggregateCollectionId()
 QContactCollectionId SeasideCache::localCollectionId()
 {
     return QtContactsSqliteExtensions::localCollectionId(manager()->managerUri());
+}
+
+SeasideActionPlugin *SeasideCache::actionPlugin()
+{
+    static SeasideActionPlugin *actionPlugin = new DefaultSeasideActionPlugin;
+    return actionPlugin;
 }
 
 QContactFilter SeasideCache::filterForMergeCandidates(const QContact &contact) const

--- a/lib/seasidecache.h
+++ b/lib/seasidecache.h
@@ -63,6 +63,8 @@
 #include <QElapsedTimer>
 #include <QAbstractListModel>
 
+class SeasideActionPlugin;
+
 QTCONTACTS_USE_NAMESPACE
 
 class CONTACTCACHE_EXPORT SeasideDisplayLabelGroupChangeListener
@@ -372,6 +374,8 @@ public:
     static QContactCollection collectionFromId(const QContactCollectionId &collectionId);
     static QContactCollectionId aggregateCollectionId();
     static QContactCollectionId localCollectionId();
+
+    static SeasideActionPlugin *actionPlugin();
 
     bool event(QEvent *event);
 

--- a/src/seasideperson.h
+++ b/src/seasideperson.h
@@ -343,6 +343,12 @@ public:
 
     Q_INVOKABLE QVariantMap decomposeName(const QString &name) const;
 
+    Q_INVOKABLE int detailIdForPhoneNumber(const QString &phoneNumber);
+    Q_INVOKABLE int detailIdForOnlineAccount(const QString &localUid, const QString &remoteUid);
+
+    Q_INVOKABLE QVariantList supportedActions(int detailType);
+    Q_INVOKABLE bool triggerAction(const QString &actionType, const QString &detailId, const QVariantMap &parameters = QVariantMap());
+
     void displayLabelOrderChanged(SeasideCache::DisplayLabelOrder order);
 
     void updateContact(const QContact &newContact, QContact *oldContact, SeasideCache::ContactState state);

--- a/src/src.pro
+++ b/src/src.pro
@@ -8,7 +8,8 @@ CONFIG += qt plugin hide_symbols
 
 QT = \
     core  \
-    qml
+    qml \
+    dbus
 PKGCONFIG += mlocale5 accounts-qt5
 
 packagesExist(mlite5) {

--- a/tests/common.pri
+++ b/tests/common.pri
@@ -4,7 +4,7 @@ include(basename.pri)
 TEMPLATE = app
 CONFIG -= app_bundle
 
-QT += testlib qml
+QT += testlib qml dbus
 
 SRCDIR = $$PWD/../src/
 INCLUDEPATH += $$SRCDIR $$PWD/../lib/

--- a/tests/tst_seasidefilteredmodel/seasidecache.cpp
+++ b/tests/tst_seasidefilteredmodel/seasidecache.cpp
@@ -489,6 +489,11 @@ QContactCollectionId SeasideCache::localCollectionId()
     return QContactCollectionId();
 }
 
+SeasideActionPlugin *SeasideCache::actionPlugin()
+{
+    return nullptr;
+}
+
 SeasideCache::DisplayLabelOrder SeasideCache::displayLabelOrder()
 {
     return FirstNameFirst;

--- a/tests/tst_seasidefilteredmodel/seasidecache.h
+++ b/tests/tst_seasidefilteredmodel/seasidecache.h
@@ -18,6 +18,7 @@
 QTCONTACTS_USE_NAMESPACE
 
 class SeasidePerson;
+class SeasideActionPlugin;
 
 class SeasideCache : public QObject
 {
@@ -228,6 +229,8 @@ public:
 
     static QContactCollectionId aggregateCollectionId();
     static QContactCollectionId localCollectionId();
+
+    static SeasideActionPlugin *actionPlugin();
 
     void populate(FilterType filterType);
     void insert(FilterType filterType, int index, const QList<quint32> &ids);


### PR DESCRIPTION
Add SeasideActionPlugin, which defines an interface for implementing
the actions that are triggered for a contact (call a contact, email a
contact etc.). DefaultSeasideActionPlugin provides a default
implementation that will launch the appropriate app for various
actions.

SeasideCache::actionPlugin() returns the default action plugin, which
is currently an instance of DefaultSeasideActionPlugin. Later on, we
can change this to find available action plugins through the Qt plugin
mechanism instead.

SeasidePerson::supportedActions() returns the available actions based
on those listed by the action plugin. SeasidePerson::triggerAction()
triggers an action using the action plugin.