### PR TITLE
[seasidecache] Remove contacts after listener notify. Fixes JB#57536

### DIFF
--- a/lib/seasidecache.h
+++ b/lib/seasidecache.h
@@ -486,6 +486,7 @@ private:
     QList<ListModel *> m_models[FilterTypesCount];
     QSet<QObject *> m_users;
     QHash<QContactId,int> m_expiredContacts;
+    QHash<QContactId,quint32> m_contactsWaitingNotify;
     QContactFetchRequest m_fetchRequest;
     QContactFetchByIdRequest m_fetchByIdRequest;
     QContactIdFetchRequest m_contactIdRequest;

--- a/lib/seasidecache.h
+++ b/lib/seasidecache.h
@@ -486,7 +486,7 @@ private:
     QList<ListModel *> m_models[FilterTypesCount];
     QSet<QObject *> m_users;
     QHash<QContactId,int> m_expiredContacts;
-    QHash<QContactId,quint32> m_contactsWaitingNotify;
+    QSet<quint32> m_contactsWaitingNotify;
     QContactFetchRequest m_fetchRequest;
     QContactFetchByIdRequest m_fetchByIdRequest;
     QContactIdFetchRequest m_contactIdRequest;


### PR DESCRIPTION
The contacts should not be removed (erased) before notify on that
contact is done. Otherwise the CacheItem does not exist anymore in some
cases when the listener notify is being done and notify is not done.

This can happen because the signal from QContactsManager can come late
when removing multiple contacts in a row and the 1 and 2 are erased as
they are marked as expired and 2 is removed before it can be notified.
It may not be noticeable during normal use but with the end-to-end tests
of libcommhistory-qt (eventmodel) do randomly fail because of this.