### PR TITLE
qmake: Add 'dbus' library to QT dependencies.

### DIFF
--- a/lib/lib.pro
+++ b/lib/lib.pro
@@ -12,7 +12,7 @@ DEFINES += CONTACTCACHE_BUILD
 CONFIG += create_pc create_prl no_install_prl
 
 QT -= gui
-QT += core
+QT += core dbus
 
 develheaders.path = /usr/include/$$TARGET
 develheaders.files = $$PUBLIC_HEADERS

--- a/src/src.pro
+++ b/src/src.pro
@@ -8,7 +8,8 @@ CONFIG += qt plugin hide_symbols
 
 QT = \
     core  \
-    qml
+    qml   \
+    dbus
 PKGCONFIG += mlocale$${QT_MAJOR_VERSION} accounts-qt$${QT_MAJOR_VERSION}
 
 packagesExist(mlite$${QT_MAJOR_VERSION}) {

--- a/tests/common.pri
+++ b/tests/common.pri
@@ -4,7 +4,7 @@ include(basename.pri)
 TEMPLATE = app
 CONFIG -= app_bundle
 
-QT += testlib qml
+QT += testlib qml dbus
 
 SRCDIR = $$PWD/../src/
 INCLUDEPATH += $$SRCDIR $$PWD/../lib/


### PR DESCRIPTION
Against Qt 5.15.x this resolves the below build failure:

```
/usr/lib/qt5/bin/moc -DHAS_GSETTINGS -DCONTACTCACHE_BUILD
-DQT_CONTACTS_LIB -DQT_CORE_LIB -DQT_VERSIT_LIB -DQT_GUI_LIB
-DQT_NO_DEBUG -DQT_CONTACTS_LIB -DQT_CORE_LIB --include
<<PKGBUILDDIR>>/lib/moc_predefs.h
-I/usr/lib/x86_64-linux-gnu/qt5/mkspecs/linux-g++
-I<<PKGBUILDDIR>>/lib
-I/usr/include/x86_64-linux-gnu/qt5/QtContacts
-I/usr/include/x86_64-linux-gnu/qt5
-I/usr/include/x86_64-linux-gnu/qt5/QtCore
-I/usr/include/x86_64-linux-gnu/qt5/QtVersit
-I/usr/include/qtcontacts-sqlite-qt5-extensions
-I/usr/include/x86_64-linux-gnu/qt5/QGSettings -I/usr/include/mlocale5
-I/usr/include/x86_64-linux-gnu/qt5/QtGui
-I/usr/include/x86_64-linux-gnu/qt5/QtContacts/5.0.0
-I/usr/include/x86_64-linux-gnu/qt5/QtContacts/5.0.0/QtContacts
-I/usr/include/x86_64-linux-gnu/qt5/QtCore/5.15.13
-I/usr/include/x86_64-linux-gnu/qt5/QtCore/5.15.13/QtCore
-I/usr/include/c++/13 -I/usr/include/x86_64-linux-gnu/c++/13
-I/usr/include/c++/13/backward -I/usr/lib/gcc/x86_64-linux-gnu/13/include
-I/usr/local/include -I/usr/include/x86_64-linux-gnu -I/usr/include
seasidecache.h -o moc_seasidecache.cpp seasidecache.cpp:48:10: fatal
error: QDBusConnection: No such file or directory    48 | #include
<QDBusConnection>
```