### PR TITLE
Fix Debian cross-building issue

### DIFF
--- a/lib/lib.pri
+++ b/lib/lib.pri
@@ -31,7 +31,7 @@ LIBS += -lphonenumber
 QT += contacts-private
 
 # We need the moc output for ContactManagerEngine from sqlite-extensions
-extensionsIncludePath = $$system(pkg-config --cflags-only-I qtcontacts-sqlite-qt$${QT_MAJOR_VERSION}-extensions)
+extensionsIncludePath = $$system($$PKG_CONFIG --cflags-only-I qtcontacts-sqlite-qt$${QT_MAJOR_VERSION}-extensions)
 VPATH += $$replace(extensionsIncludePath, -I, )
 HEADERS += \
     contactmanagerengine.h \


### PR DESCRIPTION
I'm forwarding a patch from Debian. By cross-building, Debian is referring to building from one Debian architecture (like amd64) for a different Debian architecture (like arm64).

https://bugs.debian.org/1126661