### PR TITLE
Allow initializing SeasideCache from client.

### DIFF
--- a/lib/seasidecache.cpp
+++ b/lib/seasidecache.cpp
@@ -728,6 +728,15 @@ void SeasideCache::unregisterChangeListener(ChangeListener *listener)
     instancePtr->m_changeListeners.removeAll(listener);
 }
 
+void SeasideCache::initialize(FetchDataType requiredTypes, FetchDataType extraTypes)
+{
+    // Ensure the cache has been instantiated
+    instance();
+
+    instancePtr->keepPopulated(requiredTypes & SeasideCache::FetchTypesMask,
+                               extraTypes & SeasideCache::FetchTypesMask);
+}
+
 void SeasideCache::unregisterResolveListener(ResolveListener *listener)
 {
     if (!instancePtr)
@@ -3165,11 +3174,16 @@ void SeasideCache::addressRequestStateChanged(QContactAbstractRequest::State sta
 
 void SeasideCache::makePopulated(FilterType filter)
 {
+    int oldPopulated = m_populated;
     m_populated |= (1 << filter);
 
     QList<ListModel *> &models = m_models[filter];
     for (int i = 0; i < models.count(); ++i)
         models.at(i)->makePopulated();
+
+    if (m_populated != oldPopulated) {
+        emit populatedChanged();
+    }
 }
 
 void SeasideCache::setSortOrder(const QString &property)

--- a/lib/seasidecache.h
+++ b/lib/seasidecache.h
@@ -358,6 +358,8 @@ public:
     static int importContacts(const QString &path);
     static QString exportContacts();
 
+    static void initialize(FetchDataType requiredTypes = FetchNone,
+                           FetchDataType extraTypes = FetchNone);
     static const QList<quint32> *contacts(FilterType filterType);
     static bool isPopulated(FilterType filterType);
 
@@ -394,6 +396,9 @@ public:
         removeRange(m_syncFilter, index, count);
         return 0;
     }
+
+signals:
+    void populatedChanged();
 
 protected:
     void timerEvent(QTimerEvent *event);


### PR DESCRIPTION
Id'like to use SeasideCache in a dbus service, so not in a UI context.
Is this accurate ?

```

SeasideCache::registerUser(this);

connect(SeasideCache::instance(), &SeasideCache::populatedChanged, this, [this]() {
    if (SeasideCache::isPopulated(SeasideCache::FilterAll)) {
        doSomeStuff()
    }
});


SeasideCache::initialize(SeasideCache::FetchPhoneNumber | SeasideCache::FetchEmailAddress);